### PR TITLE
Stop Entry support via the experimental client that didn't use Newtonsoft JSON. Uses Global  API.

### DIFF
--- a/Clockify.Net/ClockifyClient.cs
+++ b/Clockify.Net/ClockifyClient.cs
@@ -23,7 +23,7 @@ namespace Clockify.Net
     public class ClockifyClient
     {
         private const string BaseUrl = "https://api.clockify.me/api/v1";
-        private const string ExperimentalApiUrl = "https://global.api.clockify.me/";
+        private const string ExperimentalApiUrl = "https://api.clockify.me/api/";
         private const string ApiKeyHeaderName = "X-Api-Key";
         private const string ApiKeyVariableName = "CAPI_KEY";
         private IRestClient _client;

--- a/Clockify.Net/ClockifyClient.cs
+++ b/Clockify.Net/ClockifyClient.cs
@@ -23,7 +23,7 @@ namespace Clockify.Net
     public class ClockifyClient
     {
         private const string BaseUrl = "https://api.clockify.me/api/v1";
-        private const string ExperimentalApiUrl = "https://api.clockify.me/api/";
+        private const string ExperimentalApiUrl = "https://global.api.clockify.me/";
         private const string ApiKeyHeaderName = "X-Api-Key";
         private const string ApiKeyVariableName = "CAPI_KEY";
         private IRestClient _client;
@@ -424,6 +424,19 @@ namespace Clockify.Net
         }
 
         /// <summary>
+        /// Ends the current time entry in the workspace.
+        /// </summary>
+        public Task<IRestResponse> EndTimeEntryAsync(string workspaceId)
+        {
+            var jsonObject = new Newtonsoft.Json.Linq.JObject();
+            // you can explicitly add values here using class interface
+            jsonObject.Add("end", DateTime.Now);
+            var request = new RestRequest($"workspaces/{workspaceId}/timeEntries/endStarted", Method.PUT);
+            request.AddJsonBody(jsonObject);
+            return _experimentalClient.ExecuteAsync(request);
+        }
+
+        /// <summary>
         /// Get time entry from. workspace. See Clockify docs for query params explanation.
         /// </summary>
         public Task<IRestResponse<TimeEntryDtoImpl>> GetTimeEntryAsync(
@@ -606,7 +619,7 @@ namespace Clockify.Net
 
             _experimentalClient = new RestClient(ExperimentalApiUrl);
             _experimentalClient.AddDefaultHeader(ApiKeyHeaderName, apiKey);
-            _client.UseNewtonsoftJson(jsonSerializerSettings);
+            _experimentalClient.UseNewtonsoftJson(jsonSerializerSettings);
         }
 
         #endregion

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,33 @@
+# .NET Desktop
+# Build and run tests for .NET Desktop or Windows classic desktop solutions.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
+
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@1
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
+
+- task: VSBuild@1
+  inputs:
+    solution: '$(solution)'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+
+- task: VSTest@2
+  inputs:
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'


### PR DESCRIPTION
New API: EndTimeEntryAsync