### PR TITLE
adds paging to FindAllUsersOnWorkspaceAsync and FindAllClientsOnWorks…

### DIFF
--- a/Clockify.Net/ClockifyClient.cs
+++ b/Clockify.Net/ClockifyClient.cs
@@ -121,9 +121,13 @@ namespace Clockify.Net
         /// <summary>
         /// Find all users on workspace
         /// </summary>
-        public Task<IRestResponse<List<UserDto>>> FindAllUsersOnWorkspaceAsync(string workspaceId)
+        public Task<IRestResponse<List<UserDto>>> FindAllUsersOnWorkspaceAsync(string workspaceId,int page=1,int pageSize = 50)
         {
             var request = new RestRequest($"workspaces/{workspaceId}/users");
+            
+            request.AddQueryParameter(nameof(page), page.ToString());
+            request.AddQueryParameter("page-size", pageSize.ToString());
+
             return _client.ExecuteGetAsync<List<UserDto>>(request);
         }
 
@@ -186,9 +190,13 @@ namespace Clockify.Net
         /// <summary>
         /// Find clients on workspace
         /// </summary>
-        public Task<IRestResponse<List<ClientDto>>> FindAllClientsOnWorkspaceAsync(string workspaceId)
+        public Task<IRestResponse<List<ClientDto>>> FindAllClientsOnWorkspaceAsync(string workspaceId,int page=1,int pageSize=50)
         {
             var request = new RestRequest($"workspaces/{workspaceId}/clients");
+
+            request.AddQueryParameter(nameof(page), page.ToString());
+            request.AddQueryParameter("page-size", pageSize.ToString());
+
             return _client.ExecuteGetAsync<List<ClientDto>>(request);
         }
 

--- a/Clockify.Tests/Tests/ClientsTests.cs
+++ b/Clockify.Tests/Tests/ClientsTests.cs
@@ -54,5 +54,18 @@ namespace Clockify.Tests.Tests
             var workspaceResponse = await _client.FindAllClientsOnWorkspaceAsync(_workspaceId);
             workspaceResponse.IsSuccessful.Should().BeTrue();
         }
+
+
+        /// <summary>
+        /// Only shows different results in comparsion to (FindAllClientsOnWorkspaceAsync_ShouldReturnClientsList)
+        /// if more han 50 clients are available in clockify
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task FindAllClientsOnWorkspaceAsync_ShouldReturnClientsListWithExtendedPageSize()
+        {
+            var workspaceResponse = await _client.FindAllClientsOnWorkspaceAsync(_workspaceId,1,10000);
+            workspaceResponse.IsSuccessful.Should().BeTrue();
+        }
     }
 }

--- a/Clockify.Tests/Tests/UserTests.cs
+++ b/Clockify.Tests/Tests/UserTests.cs
@@ -53,9 +53,22 @@ namespace Clockify.Tests.Tests
         }
 
         [Test]
-        public async Task FindAllUsersOnWorkspace_GoodWorkspace_ShouldReturnCurrentUser()
+        public async Task FindAllUsersOnWorkspace_GoodWorkspace_ShouldReturnCurrentUsers()
         {
             var response = await _client.FindAllUsersOnWorkspaceAsync(_workspaceId);
+            response.IsSuccessful.Should().BeTrue();
+            response.Data.Should().NotBeNullOrEmpty();
+        }
+
+        /// <summary>
+        /// Only shows different results in comparsion to (FindAllUsersOnWorkspace_GoodWorkspace_ShouldReturnCurrentUsers)
+        /// if more han 50 users are available in clockify
+        /// </summary>
+        /// <returns></returns>
+        [Test]
+        public async Task FindAllUsersOnWorkspace_GoodWorkspace_ShouldReturnCurrentUsersWithExtendedPageSize()
+        {
+            var response = await _client.FindAllUsersOnWorkspaceAsync(_workspaceId,1,10000);
             response.IsSuccessful.Should().BeTrue();
             response.Data.Should().NotBeNullOrEmpty();
         }


### PR DESCRIPTION
…paceAsync, because if you have more than 50 users, the rest wont be shown by the api which will cause much trouble..