### PR TITLE
Fixes #63 - Detailed report returns list of tag objects, not strings

### DIFF
--- a/Clockify.Net/Models/Reports/TagDto.cs
+++ b/Clockify.Net/Models/Reports/TagDto.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Clockify.Net.Models.Reports
+{
+    public class TagDto
+    {
+        [JsonProperty("_id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/Clockify.Net/Models/Reports/TimeEntryDto.cs
+++ b/Clockify.Net/Models/Reports/TimeEntryDto.cs
@@ -14,7 +14,7 @@ namespace Clockify.Net.Models.Reports
         public TimeIntervalDto TimeInterval { get; set; }
         public string ApprovalRequestId { get; set; }
         public string TaskName { get; set; }
-        public List<string> Tags { get; set; }
+        public List<TagDto> Tags { get; set; }
         public bool? IsLocked { get; set; }
         public List<CustomFieldDto> CustomFields { get; set; }
         public InvoicingInfoDto InvoicingInfo { get; set; }


### PR DESCRIPTION
Fixes #63 