### PR TITLE
Add json property name attribute to Id

### DIFF
--- a/Clockify.Net/Models/Reports/TimeEntryDto.cs
+++ b/Clockify.Net/Models/Reports/TimeEntryDto.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 using Clockify.Net.Models.TimeEntries;
 
 namespace Clockify.Net.Models.Reports
 {
     public class TimeEntryDto
     {
+        [JsonProperty("_id")]
         public string Id { get; set; }
         public string Description { get; set; }
         public string UserId { get; set; }


### PR DESCRIPTION
Fixes a bug encountered during development of an application where deserialized Id in TimeEntryDto objects was null, because the property in the JSON content being returned was named with an underscore. Added the JsonProperty attribute to fix the issue.